### PR TITLE
Update Node.js from 20 -> 24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,5 +14,5 @@ inputs:
     defaultValue: 9.58.0
     required: true
 runs:
-  using: node20
+  using: node24
   main: dist/index.js


### PR DESCRIPTION
The following should address a warning github currently generates for using setup-sde@v3.0 and could lead to it becoming non-functional in the next few weeks:

```
Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: petarpetrovt/setup-sde@2a27a21f27212e473f3cc59a6dac97d8dffe8970. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
```

The change is so far untested..